### PR TITLE
Compatability fix for SilverStripe 3.0

### DIFF
--- a/code/SpamProtectorField.php
+++ b/code/SpamProtectorField.php
@@ -12,6 +12,14 @@ abstract class SpamProtectorField extends FormField {
 	 * @var array
 	 */
 	private $spamFieldMapping = array();
+    
+    function __construct($name, $title = null, $value = null, $form = null, $rightTitle = null) {
+		parent::__construct($name, $title, $value);
+        
+        if(!empty($form)) {
+            $this->form=$form;
+        }
+    }
 	
 	
 	/**


### PR DESCRIPTION
In SS3.0 spam protection does not set the form binding when adding a SpamProtectorField to a form using SpamProtectorManager::update_form()
