### PR TITLE
BUG Fixed incorrect field specification

### DIFF
--- a/code/extensions/CommentSpamProtection.php
+++ b/code/extensions/CommentSpamProtection.php
@@ -17,7 +17,7 @@ class CommentSpamProtection extends Extension {
 			'Name' => 'author_name', 
 			'CommenterURL' => 'author_url', 
 			'Comment' => 'post_body', 
-			'Email' => 'author_email'
+			'Email' => 'author_mail'
 		));
 	}
 }


### PR DESCRIPTION
Email spam field (for Mollom, which I presume this extension is targetting) should be author_mail not author_email

https://github.com/silverstripe/silverstripe-mollom/blob/master/code/MollomField.php#L28
