### PR TITLE
API Re-introduced ability to insert spam field before another existing field

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Options to configure are:
 
 *`name`* the form field name argument for the Captcha. Defaults to `Catcha`.
 *`title`* title of the Captcha form field. Defaults to `''`
+*`insertBefore`* name of existing field to insert the spam protection field prior to
 *`mapping`* an array mapping of the Form fields to the standardized list of 
 field names. The list of standardized fields to pass to the spam protector are:
 

--- a/code/extensions/FormSpamProtectionExtension.php
+++ b/code/extensions/FormSpamProtectionExtension.php
@@ -93,7 +93,15 @@ class FormSpamProtectionExtension extends Extension {
 		if($field = $protector->getFormField($name, $title)) {
 			$field->setForm($this->owner);
 			
-			$this->owner->Fields()->push($field);
+			// Add before field specified by insertBefore
+			$inserted = false;
+			if(!empty($options['insertBefore'])) {
+				$inserted = $this->owner->Fields()->insertBefore($field, $options['insertBefore']);
+			}
+			if(!$inserted) {
+				// Add field to end if not added already
+				$this->owner->Fields()->push($field);
+			}
 		}
 	
 		return $this->owner;

--- a/tests/FormSpamProtectionExtensionTest.php
+++ b/tests/FormSpamProtectionExtensionTest.php
@@ -5,6 +5,8 @@
  */
 class FormSpamProtectionExtensionTest extends SapphireTest {
 	
+	protected $usesDatabase = false;
+	
 	public function setUp() {
 		parent::setUp();
 
@@ -54,6 +56,36 @@ class FormSpamProtectionExtensionTest extends SapphireTest {
 
 		$this->assertEquals('Qux', $form->Fields()->fieldByName('Borris')->Title());
 	}
+	
+	public function testInsertBefore() {
+		
+		$form = $this->form->enableSpamProtection(array(
+			'protector' => 'FormSpamProtectionExtensionTest_FooProtector',
+			'insertBefore' => 'URL'
+		));
+		
+		$fields = $form->Fields();
+		$this->assertEquals('Title', $fields[0]->Title());
+		$this->assertEquals('Comment', $fields[1]->Title());
+		$this->assertEquals('Foo', $fields[2]->Title());
+		$this->assertEquals('URL', $fields[3]->Title());
+	}
+	
+	public function testInsertBeforeMissing() {
+		
+		$form = $this->form->enableSpamProtection(array(
+			'protector' => 'FormSpamProtectionExtensionTest_FooProtector',
+			'insertBefore' => 'NotAField'
+		));
+		
+		// field should default to the end instead
+		$fields = $form->Fields();
+		$this->assertEquals('Title', $fields[0]->Title());
+		$this->assertEquals('Comment', $fields[1]->Title());
+		$this->assertEquals('URL', $fields[2]->Title());
+		$this->assertEquals('Foo', $fields[3]->Title());
+	}
+	
 }
 
 /**


### PR DESCRIPTION
I was updating an old site to use the new spam protector module, when I realised that the ability to specify the "insert before" field when adding the captcha field has been removed.

I've reintroduced this option with tests and documentation. :) To be careful, I've added a check to ensure the field you specify exists. The module will fallback to adding to the end if it doesn't.
