### PR TITLE
BUGFIX: Stop attempting to filter an UnsavedRelationList

### DIFF
--- a/code/EditableSpamProtectionField.php
+++ b/code/EditableSpamProtectionField.php
@@ -73,6 +73,10 @@ if(class_exists('EditableFormField')) {
 			$protector = FormSpamProtectionExtension::get_protector();
 			if (!$protector) return $fields;
 			
+			if ($this->Parent()->Fields() instanceof UnsavedRelationList) {
+				return $fields;
+			}
+			
 			// Each other text field in this group can be assigned a field mapping
 			$mapGroup = FieldGroup::create(_t(
 				'EditableSpamProtectionField.SPAMFIELDMAPPING',


### PR DESCRIPTION
I have come across an issue on a site where a UserDefinedForm was removed from the Draft site, and ceased to be accessible within the CMS (raising an error 'Uncaught LogicException: filter can't be called on an UnsavedRelationList'), with SpamProtection at the top of the call stack. I worked with Michael Strong to produce a simple solution to the issue.

Unfortunately I have been unable to reproduce the issue on a fresh copy of Silverstripe, but this should help avoid issues in edge-case sites.