### PR TITLE
Provide possibility of meaningful error messages when using UserForms

### DIFF
--- a/code/EditableSpamProtectionField.php
+++ b/code/EditableSpamProtectionField.php
@@ -112,17 +112,14 @@ if (class_exists('EditableFormField')) {
 
         public function validateField($data, $form)
         {
-            // In case you dont have this function in your php - primitive version
-            if (!function_exists("array_column")) {
-                function array_column($array, $column_name) {
-                    return array_map(function ($element) use ($column_name) {
-                        return $element[$column_name];
-                    }, $array);
-                }
-            }
             if (!$formField->validate($form->getValidator())) {
                 $errorArray = $form->getValidator()->getErrors();
-                $errorText = $errorArray[array_search($this->Name, array_column($errorArray, 'fieldName'))]['message'];
+                
+                $map = array_map(function ($element) {
+                    return $element['fieldName'];
+                }, $errorArray);
+
+                $errorText = $errorArray[array_search($this->Name, $map)]['message'];
                 $form->addErrorMessage($this->Name, $errorText, 'error', false);
             }
         }

--- a/code/EditableSpamProtectionField.php
+++ b/code/EditableSpamProtectionField.php
@@ -112,9 +112,18 @@ if (class_exists('EditableFormField')) {
 
         public function validateField($data, $form)
         {
-            $formField = $this->getFormField();
+            // In case you dont have this function in your php - primitive version
+            if (!function_exists("array_column")) {
+                function array_column($array, $column_name) {
+                    return array_map(function ($element) use ($column_name) {
+                        return $element[$column_name];
+                    }, $array);
+                }
+            }
             if (!$formField->validate($form->getValidator())) {
-                $form->addErrorMessage($this->Name, $this->getErrorMessage()->HTML(), 'error', false);
+                $errorArray = $form->getValidator()->getErrors();
+                $errorText = $errorArray[array_search($this->Name, array_column($errorArray, 'fieldName'))]['message'];
+                $form->addErrorMessage($this->Name, $errorText, 'error', false);
             }
         }
 


### PR DESCRIPTION
Another fork with useful error message return to UserForms. Tested with multiple spam modules in one Userforms page. Slightly simpler than the other version