### PR TITLE
Provide possibility of meaningful error messages when using UserForms

### DIFF
--- a/code/EditableSpamProtectionField.php
+++ b/code/EditableSpamProtectionField.php
@@ -114,7 +114,14 @@ if (class_exists('EditableFormField')) {
         {
             $formField = $this->getFormField();
             if (!$formField->validate($form->getValidator())) {
-                $form->addErrorMessage($this->Name, $this->getErrorMessage()->HTML(), 'error', false);
+                $errorArray = $form->getValidator()->getErrors();
+                
+                $map = array_map(function ($element) {
+                    return $element['fieldName'];
+                }, $errorArray);
+
+                $errorText = $errorArray[array_search($this->Name, $map)]['message'];
+                $form->addErrorMessage($this->Name, $errorText, 'error', false);
             }
         }
 


### PR DESCRIPTION
Another fork with useful error message return to UserForms. Tested with multiple spam modules in one Userforms page. Slightly simpler than the other version

ThIs differs from the removed pull request in that there is no missing < php 5.5 array_column function subsititution. Php array_map is used directly in validateField() 
