### PR TITLE
API Enable spam protectors to receive configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,25 +66,26 @@ implementation client side or server side.
 
 Options to configure are:
 
-*`protector`* a class name string or class instance which implements 
-`SpamProtector`. Defaults to your 
+* `protector`: a class name string or class instance which implements  `SpamProtector`. Defaults to your 
 `FormSpamProtectionExtension.default_spam_protector` value.
+* `name`: The form field name argument for the Captcha. Defaults to `Catcha`.
+* `title`: title of the Captcha form field. Defaults to `''`
+* `insertBefore`: name of existing field to insert the spam protection field prior to
+* `mapping`: an array mapping of the Form fields to the standardized list of field names.
+The list of standardized fields to pass to the spam protector are:
+  * title
+  * body
+  * contextUrl
+  * contextTitle
+  * authorName
+  * authorMail
+  * authorUrl
+  * authorIp
+  * authorId
 
-*`name`* the form field name argument for the Captcha. Defaults to `Catcha`.
-*`title`* title of the Captcha form field. Defaults to `''`
-*`insertBefore`* name of existing field to insert the spam protection field prior to
-*`mapping`* an array mapping of the Form fields to the standardized list of 
-field names. The list of standardized fields to pass to the spam protector are:
-
-		title
-		body
-		contextUrl
-		contextTitle
-		authorName
-		authorMail
-		authorUrl
-		authorIp
-		authorId
+Additional options may be specified, which may be used to activate implementation specific
+features for the chosen spam protector. All of these options will be passed to the
+protector constructor (see below).
 
 ## Defining your own `SpamProtector`
 
@@ -93,16 +94,32 @@ be set as the spam protector. The `getFormField()` method returns the
 `FormField` to be inserted into the `Form`. The `FormField` returned should be
 in charge of the validation process.
 
-	<?php
-
-	class CustomSpamProtector implements SpamProtector {
-
-		public function getFormField($name = null, $title = null, $value = null) {
-			// CaptchaField is a imagined class which has some functionality.
-			// See silverstripe-mollom module for an example.
-			return new CaptchaField($name, $title, $value);
-		}
-	}
+    <?php
+    
+    class CustomSpamProtector implements SpamProtector
+    {
+        /**
+         * List of options passed to enableSpamProtection() used to generate this protector
+         * @var array
+         */
+        protected $options = array();
+    
+        public function __construct($options = array())
+        {
+            $this->options = $options;
+        }
+    
+        public function getFormField($name = null, $title = null, $value = null)
+        {
+            // CaptchaField is a imagined class which has some functionality.
+            // See silverstripe-mollom module for an example.
+            return new CaptchaField($name, $title, $value);
+        }
+        
+        public function setFieldMapping($fieldMapping) {
+            // No-op
+        }
+    }
 
 
 ## Using Spam Protection with User Forms

--- a/code/extensions/FormSpamProtectionExtension.php
+++ b/code/extensions/FormSpamProtectionExtension.php
@@ -57,7 +57,7 @@ class FormSpamProtectionExtension extends Extension
         }
 
         if ($protector && class_exists($protector)) {
-            return Injector::inst()->create($protector);
+            return Injector::inst()->createWithArgs($protector, array($options));
         } else {
             return null;
         }

--- a/code/interfaces/SpamProtector.php
+++ b/code/interfaces/SpamProtector.php
@@ -15,6 +15,12 @@
 interface SpamProtector
 {
     /**
+     * SpamProtector constructor.
+     * @param array $options List of spam protection options
+     */
+    public function __construct($options = array());
+
+    /**
      * Return the {@link FormField} associated with this protector.
      *
      * Most spam methods will simply return a piece of HTML to be injected at 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.0.x-dev"
+			"dev-master": "3.0.x-dev"
 		}
 	},
 	"license": "BSD-3-Clause"

--- a/tests/FormSpamProtectionExtensionTest.php
+++ b/tests/FormSpamProtectionExtensionTest.php
@@ -61,10 +61,13 @@ class FormSpamProtectionExtensionTest extends SapphireTest
         $form = $this->form->enableSpamProtection(array(
             'protector' => 'FormSpamProtectionExtensionTest_BazProtector',
             'title' => 'Qux',
-            'name' => 'Borris'
+            'name' => 'Borris',
+            'righttitle' => 'Lipsum'
         ));
 
-        $this->assertEquals('Qux', $form->Fields()->fieldByName('Borris')->Title());
+        $formfield = $form->Fields()->fieldByName('Borris');
+        $this->assertEquals('Qux', $formfield->Title());
+        $this->assertEquals('Lipsum', $formfield->RightTitle());
     }
     
     public function testInsertBefore()
@@ -102,9 +105,20 @@ class FormSpamProtectionExtensionTest extends SapphireTest
  */
 class FormSpamProtectionExtensionTest_BazProtector implements SpamProtector, TestOnly
 {
+    protected $options = array();
+
+    public function __construct($options = array())
+    {
+        $this->options = $options;
+    }
+
     public function getFormField($name = null, $title = null, $value = null)
     {
-        return new TextField($name, $title, $value);
+        $field = new TextField($name, $title, $value);
+        if(isset($this->options['righttitle'])) {
+            $field->setRightTitle($this->options['righttitle']);
+        }
+        return $field;
     }
 
     public function setFieldMapping($fieldMapping)
@@ -117,6 +131,10 @@ class FormSpamProtectionExtensionTest_BazProtector implements SpamProtector, Tes
  */
 class FormSpamProtectionExtensionTest_BarProtector implements SpamProtector, TestOnly
 {
+    public function __construct($options = array())
+    {
+    }
+
     public function getFormField($name = null, $title = null, $value = null)
     {
         $title = $title ?: 'Bar';
@@ -133,6 +151,10 @@ class FormSpamProtectionExtensionTest_BarProtector implements SpamProtector, Tes
  */
 class FormSpamProtectionExtensionTest_FooProtector implements SpamProtector, TestOnly
 {
+    public function __construct($options = array())
+    {
+    }
+
     public function getFormField($name = null, $title = null, $value = null)
     {
         return new TextField($name, 'Foo', $value);


### PR DESCRIPTION
As this feature is a breaking change (as it now requires all spam protectors to implement a constructor) I've bumped the dev-master alias to 3.0. If this is merged I'll also fork the old master to a 2 branch to allow older spam protectors to continue to work.

This feature is necessary to enable spam protectors to implement protector-specific features, some of which are currently hacked into the core module.

E.g. CommentSpamProtection currently sets the field name to `IsSpam`, which actually only works properly with the akismet protector, and should probably be refactored into a module-specific feature.

This will allow SpamProtector implementors to be a lot more flexible in their configuration.

Module PRs:
- https://github.com/silverstripe/silverstripe-mathspamprotection/pull/43
- https://github.com/silverstripe/silverstripe-akismet/pull/18
