### PR TITLE
Set Form for formField when validating

### DIFF
--- a/code/EditableSpamProtectionField.php
+++ b/code/EditableSpamProtectionField.php
@@ -142,7 +142,8 @@ if (class_exists('EditableFormField')) {
         public function validateField($data, $form) 
         {
             $formField = $this->getFormField();
-            
+            $formField->setForm($form);
+
             if (isset($data[$this->Name])) {
                 $formField->setValue($data[$this->Name]);
             }


### PR DESCRIPTION
When using EditableSpamProtectionField with UserForms 3.0, forms
with a spam protector field (defined from FormSpamProtectorExtension),
form submissions return an error:

PHP Fatal error:  Call to a member function FormName() on a non-object

This because the exemplar formField generated by getFormField() does
not have any connection to the particular form being submitted.  This
is fixed with a simple setForm() call in the validateField() function