### PR TITLE
Configurable fieldname

### DIFF
--- a/code/extensions/FormSpamProtectionExtension.php
+++ b/code/extensions/FormSpamProtectionExtension.php
@@ -74,6 +74,8 @@ class FormSpamProtectionExtension extends Extension
         // captcha form field name (must be unique)
         if (isset($options['name'])) {
             $name = $options['name'];
+        } else if($field_name = Config::inst()->get('FormSpamProtectionExtension', 'field_name')) {
+            $name = $field_name;
         } else {
             $name = 'Captcha';
         }

--- a/code/extensions/FormSpamProtectionExtension.php
+++ b/code/extensions/FormSpamProtectionExtension.php
@@ -42,6 +42,15 @@ class FormSpamProtectionExtension extends Extension
     );
     
     /**
+     * @config
+     *
+     * The field name to use for the {@link SpamProtector} {@link FormField}
+     *
+     * @var string $spam_protector
+     */
+    private static $field_name = "Captcha";
+    
+    /**
      * Instantiate a SpamProtector instance
      *
      * @param array $options Configuration options
@@ -74,10 +83,8 @@ class FormSpamProtectionExtension extends Extension
         // captcha form field name (must be unique)
         if (isset($options['name'])) {
             $name = $options['name'];
-        } else if($field_name = Config::inst()->get('FormSpamProtectionExtension', 'field_name')) {
-            $name = $field_name;
         } else {
-            $name = 'Captcha';
+            $name = Config::inst()->get('FormSpamProtectionExtension', 'field_name');
         }
 
         // captcha field title

--- a/tests/FormSpamProtectionExtensionTest.php
+++ b/tests/FormSpamProtectionExtensionTest.php
@@ -23,6 +23,9 @@ class FormSpamProtectionExtensionTest extends SapphireTest
         ), new FieldList()
         );
         $this->form->disableSecurityToken();
+        
+        //for the tests, ignore any field_name value set in config
+        Config::inst()->remove('FormSpamProtectionExtension', 'field_name');
     }
 
     public function testEnableSpamProtection()
@@ -65,6 +68,24 @@ class FormSpamProtectionExtensionTest extends SapphireTest
         ));
 
         $this->assertEquals('Qux', $form->Fields()->fieldByName('Borris')->Title());
+    }
+    
+    public function testConfigurableName()
+    {
+        $field_name = "test_configurable_name";
+        Config::inst()->update(
+            'FormSpamProtectionExtension', 'default_spam_protector',
+            'FormSpamProtectionExtensionTest_FooProtector'
+        );
+        Config::inst()->update(
+            'FormSpamProtectionExtension', 'field_name',
+            $field_name
+        );
+        $form = $this->form->enableSpamProtection();
+        // remove for subsequent tests
+        Config::inst()->remove('FormSpamProtectionExtension', 'field_name');
+        // field should take up configured name
+        $this->assertEquals('Foo', $form->Fields()->fieldByName($field_name)->Title());
     }
     
     public function testInsertBefore()

--- a/tests/FormSpamProtectionExtensionTest.php
+++ b/tests/FormSpamProtectionExtensionTest.php
@@ -23,9 +23,6 @@ class FormSpamProtectionExtensionTest extends SapphireTest
         ), new FieldList()
         );
         $this->form->disableSecurityToken();
-        
-        //for the tests, ignore any field_name value set in config
-        Config::inst()->remove('FormSpamProtectionExtension', 'field_name');
     }
 
     public function testEnableSpamProtection()


### PR DESCRIPTION
This change allows for a configurable field name to be used as the name of the spam protection field.

Some modules create fields without a 'name' defined in enableSpamProtection() - resulting in the fieldname being "Captcha" which could be detected by spam bots and ignored. Allowing a configurable, nondescript  field name would reduce the risk of that occurring.