### PR TITLE
FIX Ensure getIcon returns exposed resource URL for icon

### DIFF
--- a/code/EditableSpamProtectionField.php
+++ b/code/EditableSpamProtectionField.php
@@ -259,15 +259,14 @@ class EditableSpamProtectionField extends EditableFormField
 
     public function getIcon()
     {
-        // Get the end of the full qualified class name
-        $shortClass = end(explode("\\", __CLASS__));
-
         $resource = ModuleLoader::getModule('silverstripe/spamprotection')
-            ->getResource('images/' . strtolower($shortClass) . '.png');
+            ->getResource('images/editablespamprotectionfield.png');
 
-        if ($resource->exists()) {
-            return $resource->getRelativePath();
+        if (!$resource->exists()) {
+            return '';
         }
+
+        return $resource->getURL();
     }
 
     public function showInReports()

--- a/tests/EditableSpamProtectionFieldTest.php
+++ b/tests/EditableSpamProtectionFieldTest.php
@@ -111,6 +111,13 @@ class EditableSpamProtectionFieldTest extends SapphireTest
         $this->assertSame('baz', $field->spamMapValue('bar'));
     }
 
+    public function testGetIcon()
+    {
+        $field = new EditableSpamProtectionField;
+
+        $this->assertContains('/images/editablespamprotectionfield.png', $field->getIcon());
+    }
+
     protected function getFormMock()
     {
         $formMock = $this->getMockBuilder(Form::class)


### PR DESCRIPTION
Follow up from #59 and https://github.com/silverstripe/silverstripe-userforms/pull/683 to ensure that the icon URL returned is exposed to the web server.