### PR TITLE
FIX incorrect instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,10 @@ following pattern:
 
 ```php
 use SilverStripe\Forms\Form;
-use SilverStripe\SpamProtection\Extension\FormSpamProtectionExtension;
 
 $form = new Form(/* .. */);
 
-if ($form->hasExtension(FormSpamProtectionExtension::class)) {
+if ($form->hasExtension('SilverStripe\SpamProtection\Extension\FormSpamProtectionExtension')) {
     $form->enableSpamProtection();
 }
 ```


### PR DESCRIPTION
In the scenario where the end-user hasn't even installed spamprotection `FormSpamProtectionExtension::class` will fail. This addresses that issue