### PR TITLE
FIX Allow fields without parents to be programatically created

### DIFF
--- a/code/EditableSpamProtectionField.php
+++ b/code/EditableSpamProtectionField.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\UnsavedRelationList;
 use SilverStripe\SpamProtection\Extension\FormSpamProtectionExtension;
 use SilverStripe\UserForms\Model\EditableFormField;
@@ -112,8 +113,11 @@ class EditableSpamProtectionField extends EditableFormField
         }
 
         // Get all candidates of the above types
-        return $this
-            ->Parent()
+        $parent = $this->Parent();
+        if (!$parent) {
+            return DataList::create(EditableFormField::class);
+        }
+        return $parent
             ->Fields()
             ->filter('ClassName', $typesInherit)
             ->exclude('Title', ''); // Ignore this field and those without titles

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require-dev": {
         "sminnee/phpunit": "^5.7",
         "silverstripe/versioned": "^1.0",
-        "squizlabs/php_codesniffer": "^3.0"
+        "squizlabs/php_codesniffer": "^3.0",
+        "silverstripe/userforms": "^5"
     },
     "extra": {
         "expose": [

--- a/tests/EditableSpamProtectionFieldTest.php
+++ b/tests/EditableSpamProtectionFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\SpamProtection\Tests;
 
+use ReflectionClass;
+use SilverStripe\ORM\DataList;
 use SilverStripe\UserForms\Model\UserDefinedForm;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
@@ -152,5 +154,25 @@ class EditableSpamProtectionFieldTest extends SapphireTest
         $editableFormFieldMock->setFormField($formFieldMock);
 
         return $editableFormFieldMock;
+    }
+
+    public function testGetCandidateFieldsParentStatus()
+    {
+        $field = new EditableSpamProtectionField();
+        $field->Name = 'MyField';
+        $reflection = new ReflectionClass($field);
+        $method = $reflection->getMethod('getCandidateFields');
+        $method->setAccessible(true);
+        // Assert with no parent
+        $list = $method->invoke($field);
+        $this->assertTrue($list instanceof DataList);
+        // Assert with parent
+        $page = new UserDefinedForm();
+        $page->write();
+        $field->ParentID = $page->ID;
+        $field->ParentClass = get_class($page);
+        $field->write();
+        $list = $method->invoke($field);
+        $this->assertTrue($list instanceof DataList);
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-spamprotection/issues/77