### PR TITLE
FIX Check  value is not NULL

### DIFF
--- a/code/Extension/FormSpamProtectionExtension.php
+++ b/code/Extension/FormSpamProtectionExtension.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\SpamProtection\Extension;
 
+use LogicException;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
@@ -84,6 +85,7 @@ class FormSpamProtectionExtension extends Extension
      * Activates the spam protection module.
      *
      * @param array $options
+     * @throws LogicException when get_protector method returns NULL.
      * @return Object
      */
     public function enableSpamProtection($options = array())
@@ -106,7 +108,11 @@ class FormSpamProtectionExtension extends Extension
         // set custom mapping on this form
         $protector = self::get_protector($options);
 
-        if (isset($options['mapping'])) {
+        if ($protector === null) {
+            throw new LogicException('No spam protector has been set. Null is not valid value.');
+        }
+
+        if ($protector && isset($options['mapping'])) {
             $protector->setFieldMapping($options['mapping']);
         }
 

--- a/tests/FormSpamProtectionExtensionTest.php
+++ b/tests/FormSpamProtectionExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\SpamProtection\Tests;
 
+use LogicException;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
@@ -36,6 +37,14 @@ class FormSpamProtectionExtensionTest extends SapphireTest
         ), new FieldList());
 
         $this->form->disableSecurityToken();
+    }
+
+    public function testEnableSpamProtectionThrowsException()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('No spam protector has been set. Null is not valid value.');
+
+        $this->form->enableSpamProtection();
     }
 
     public function testEnableSpamProtection()


### PR DESCRIPTION
### Description
`FormSpamProtectionExtension::get_protector($options = null)` returns null if `$options` is null or `$options['protector']` doesn't exist and `'default_spam_protector'` config don't set up.
Additional check for NULL was added before invoke `SpamProtector` class methods.

### Parent issue
- https://github.com/silverstripe/silverstripe-spamprotection/issues/87