### PR TITLE
MNT Explicitly test with default_spam_protector set to null

### DIFF
--- a/tests/FormSpamProtectionExtensionTest.php
+++ b/tests/FormSpamProtectionExtensionTest.php
@@ -44,6 +44,7 @@ class FormSpamProtectionExtensionTest extends SapphireTest
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('No spam protector has been set. Null is not valid value.');
 
+        Config::modify()->set(FormSpamProtectionExtension::class, 'default_spam_protector', null);
         $this->form->enableSpamProtection();
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10402

Fixes https://github.com/silverstripe/recipe-blog/actions/runs/3945201195/jobs/6751878203#step:12:130
`1) SilverStripe\SpamProtection\Tests\FormSpamProtectionExtensionTest::testEnableSpamProtectionThrowsException
Failed asserting that exception of type "LogicException" is thrown.`