### PR TITLE
MNT Explicitly test with default_spam_protector set to null

### DIFF
--- a/tests/FormSpamProtectionExtensionTest.php
+++ b/tests/FormSpamProtectionExtensionTest.php
@@ -44,6 +44,7 @@ class FormSpamProtectionExtensionTest extends SapphireTest
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('No spam protector has been set. Null is not valid value.');
 
+        Config::modify()->set(FormSpamProtectionExtension::class, 'default_spam_protector', null);
         $this->form->enableSpamProtection();
     }
 


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-blog/actions/runs/3958908794/jobs/6781048592#step:12:69
`1) SilverStripe\SpamProtection\Tests\FormSpamProtectionExtensionTest::testEnableSpamProtectionThrowsException
Failed asserting that exception of type "LogicException" is thrown.`

Happens on recipe installs that includes something that makes itself a default spam protector, such as silverstripe-akismet

Back port of https://github.com/silverstripe/silverstripe-spamprotection/pull/89

Regression caused by https://github.com/silverstripe/silverstripe-spamprotection/pull/88