### PR TITLE
MNT Use caret version of dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpunit/phpunit": "^11.3",
         "silverstripe/versioned": "^3",
         "squizlabs/php_codesniffer": "^3",
-        "silverstripe/userforms": "7.x-dev",
+        "silverstripe/userforms": "^7",
         "silverstripe/standards": "^1",
         "phpstan/extension-installer": "^1.3"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/453

Fix https://github.com/silverstripe/silverstripe-spamprotection/actions/runs/17342886394/job/49239106887

[userforms requires framework ^6.1](https://github.com/silverstripe/silverstripe-userforms/blob/7/composer.json#L34) - so CI needs installer 6.1, but it's trying to use installer 6.0