### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/EditableSpamProtectionFieldTest.php
+++ b/tests/EditableSpamProtectionFieldTest.php
@@ -160,7 +160,6 @@ class EditableSpamProtectionFieldTest extends SapphireTest
         $field->Name = 'MyField';
         $reflection = new ReflectionClass($field);
         $method = $reflection->getMethod('getCandidateFields');
-        $method->setAccessible(true);
         // Assert with no parent
         $list = $method->invoke($field);
         $this->assertTrue($list instanceof DataList);


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.